### PR TITLE
[UIMA-5964] avoid null value of unsorted variable.

### DIFF
--- a/ConceptMapper/src/main/java/org/apache/uima/conceptMapper/support/dictionaryResource/DictionaryResource_impl.java
+++ b/ConceptMapper/src/main/java/org/apache/uima/conceptMapper/support/dictionaryResource/DictionaryResource_impl.java
@@ -872,10 +872,9 @@ public class DictionaryResource_impl implements DictionaryResource, SharedResour
 
           String[] elements = (String[]) tokens.toArray(new String[tokens.size()]);
 
-          String unsorted = null;
+          String unsorted = stringTogetherTokens(elements);
 
           if (sortElements) {
-            unsorted = stringTogetherTokens(elements);
             Arrays.sort(elements);
           }
 


### PR DESCRIPTION
Fix for the bug [UIMA-5964]. Matched text field of concept mapper was always null when OrderIndependentLookup is false. With this fix, matched text is initialized independently of  OrderIndependentLookup.